### PR TITLE
Ensure early lessons keep evolving source

### DIFF
--- a/Lession 00 - Prerequisites/source/.github/workflows/ci-cd.yml
+++ b/Lession 00 - Prerequisites/source/.github/workflows/ci-cd.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    paths: [ '**/source/**' ]
+  pull_request:
+    paths: [ '**/source/**' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pwsh 'Lession 00 - Prerequisites/source/tests/verify-prerequisites.ps1'

--- a/Lession 00 - Prerequisites/source/azure-pipelines.yml
+++ b/Lession 00 - Prerequisites/source/azure-pipelines.yml
@@ -1,0 +1,13 @@
+trigger:
+- '*'
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- checkout: self
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.11'
+- script: pwsh "Lession 00 - Prerequisites/source/tests/verify-prerequisites.ps1"
+  displayName: 'Run verify prerequisites'

--- a/Lession 00 - Prerequisites/source/requirements.txt
+++ b/Lession 00 - Prerequisites/source/requirements.txt
@@ -1,0 +1,2 @@
+# dev / test dependencies
+pytest>=7.0,<8.0

--- a/Lession 01 - Hello World/source/tests/verify-prerequisites.ps1
+++ b/Lession 01 - Hello World/source/tests/verify-prerequisites.ps1
@@ -1,0 +1,28 @@
+Write-Host "Checking prerequisites..." -ForegroundColor Cyan
+
+$missing = @()
+
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    $missing += 'Python'
+} else {
+    python --version
+}
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    $missing += 'Git'
+} else {
+    git --version
+}
+
+if (-not (Get-Command code -ErrorAction SilentlyContinue)) {
+    $missing += 'VSCode'
+} else {
+    code --version
+}
+
+if ($missing.Count -eq 0) {
+    Write-Host "All prerequisites found." -ForegroundColor Green
+} else {
+    Write-Host "Missing: $($missing -join ', ')" -ForegroundColor Red
+    exit 1
+}

--- a/Lession 02 - Virtual Environment/source/src/greetings.py
+++ b/Lession 02 - Virtual Environment/source/src/greetings.py
@@ -1,0 +1,8 @@
+from .utils import normalize_title
+
+
+def greet(name: str | None) -> str:
+    """Return a friendly greeting."""
+    if not name:
+        raise ValueError("Name required")
+    return f"What TaskMate – Hello, {normalize_title(name)}!"

--- a/Lession 02 - Virtual Environment/source/src/math_example.py
+++ b/Lession 02 - Virtual Environment/source/src/math_example.py
@@ -1,0 +1,6 @@
+
+def remaining_tasks(total: int, completed: int) -> int:
+    """Return how many tasks remain."""
+    if total < 0 or completed < 0 or completed > total:
+        raise ValueError("invalid numbers")
+    return total - completed

--- a/Lession 02 - Virtual Environment/source/src/schedule_example.py
+++ b/Lession 02 - Virtual Environment/source/src/schedule_example.py
@@ -1,0 +1,10 @@
+from datetime import datetime, timedelta
+
+
+def schedule_next(minutes_from_now: int, now: datetime | None = None) -> datetime:
+    """Return the timestamp minutes from ``now``."""
+    if minutes_from_now < 0:
+        raise ValueError("minutes must be positive")
+    if now is None:
+        now = datetime.now()
+    return now + timedelta(minutes=minutes_from_now)

--- a/Lession 02 - Virtual Environment/source/src/time_example.py
+++ b/Lession 02 - Virtual Environment/source/src/time_example.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+
+def elapsed_seconds(start: datetime, end: datetime) -> float:
+    """Return elapsed seconds between two timestamps."""
+    if start is None or end is None:
+        raise ValueError("start and end required")
+    if end < start:
+        raise ValueError("end before start")
+    return (end - start).total_seconds()
+
+
+def format_duration(start: datetime, end: datetime) -> str:
+    """Return duration formatted as 'Xm Ys'."""
+    seconds = elapsed_seconds(start, end)
+    if seconds <= 0:
+        raise ValueError("invalid duration")
+    minutes, secs = divmod(seconds, 60)
+    return f"{int(minutes)}m {int(secs)}s"

--- a/Lession 02 - Virtual Environment/source/src/types_example.py
+++ b/Lession 02 - Virtual Environment/source/src/types_example.py
@@ -1,0 +1,22 @@
+from typing import Iterable, Tuple, Any
+
+
+def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type]]:
+    """Return sample values and their types.
+
+    Raises ValueError if any value is ``None``.
+    """
+    if values is None:
+        values = [
+            1,
+            "Open Store",
+            True,
+            [1.0, 2.5, 3.0],
+            {1: "Open Store"},
+        ]
+    result = []
+    for val in values:
+        if val is None:
+            raise ValueError("value is missing")
+        result.append((val, type(val)))
+    return result

--- a/Lession 02 - Virtual Environment/source/src/utils.py
+++ b/Lession 02 - Virtual Environment/source/src/utils.py
@@ -1,0 +1,3 @@
+def normalize_title(raw: str) -> str:
+    """Capitalize each word and strip whitespace."""
+    return raw.strip().title()

--- a/Lession 02 - Virtual Environment/source/tests/test_greetings.py
+++ b/Lession 02 - Virtual Environment/source/tests/test_greetings.py
@@ -1,0 +1,13 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+
+from src.greetings import greet
+
+def test_greet():
+    assert greet("sofia") == "What TaskMate – Hello, Sofia!"
+
+def test_greet_missing():
+    with pytest.raises(ValueError, match="Name required"):
+        greet("")

--- a/Lession 02 - Virtual Environment/source/tests/test_math_example.py
+++ b/Lession 02 - Virtual Environment/source/tests/test_math_example.py
@@ -1,0 +1,15 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from src.math_example import remaining_tasks
+
+
+
+def test_remaining_tasks():
+    assert remaining_tasks(5, 2) == 3
+
+
+def test_remaining_tasks_invalid():
+    with pytest.raises(ValueError):
+        remaining_tasks(5, 6)

--- a/Lession 02 - Virtual Environment/source/tests/test_schedule_example.py
+++ b/Lession 02 - Virtual Environment/source/tests/test_schedule_example.py
@@ -1,0 +1,20 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from datetime import datetime, timedelta
+
+from src.schedule_example import schedule_next
+
+
+
+def test_schedule_next():
+    now = datetime(2023, 1, 1, 12, 0, 0)
+    result = schedule_next(30, now)
+    assert result == now + timedelta(minutes=30)
+
+
+def test_schedule_next_invalid():
+    now = datetime(2023, 1, 1, 12, 0, 0)
+    with pytest.raises(ValueError):
+        schedule_next(-5, now)

--- a/Lession 02 - Virtual Environment/source/tests/test_time_example.py
+++ b/Lession 02 - Virtual Environment/source/tests/test_time_example.py
@@ -1,0 +1,32 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from datetime import datetime, timedelta
+
+from src.time_example import elapsed_seconds, format_duration
+
+
+
+def test_elapsed_seconds():
+    start = datetime(2023, 1, 1, 0, 0, 0)
+    end = start + timedelta(seconds=5)
+    assert elapsed_seconds(start, end) == 5.0
+
+
+def test_elapsed_seconds_invalid():
+    start = datetime(2023, 1, 1, 0, 0, 0)
+    with pytest.raises(ValueError):
+        elapsed_seconds(start, start - timedelta(seconds=1))
+
+
+def test_format_duration():
+    start = datetime(2023, 1, 1, 0, 0, 0)
+    end = start + timedelta(seconds=65)
+    assert format_duration(start, end) == "1m 5s"
+
+
+def test_format_duration_invalid():
+    start = datetime(2023, 1, 1, 0, 0, 0)
+    with pytest.raises(ValueError):
+        format_duration(start, start)

--- a/Lession 02 - Virtual Environment/source/tests/test_types_example.py
+++ b/Lession 02 - Virtual Environment/source/tests/test_types_example.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+
+from src.types_example import get_value_types
+
+
+
+def test_get_value_types_defaults():
+    items = get_value_types()
+    assert (1, int) in items
+    assert ("Open Store", str) in items
+
+
+def test_get_value_types_invalid():
+    with pytest.raises(ValueError):
+        get_value_types([1, None])

--- a/Lession 02 - Virtual Environment/source/tests/test_utils.py
+++ b/Lession 02 - Virtual Environment/source/tests/test_utils.py
@@ -1,0 +1,8 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from src.utils import normalize_title
+
+def test_normalize_title():
+    assert normalize_title("  hello world ") == "Hello World"

--- a/Lession 02 - Virtual Environment/source/tests/verify-prerequisites.ps1
+++ b/Lession 02 - Virtual Environment/source/tests/verify-prerequisites.ps1
@@ -1,0 +1,28 @@
+Write-Host "Checking prerequisites..." -ForegroundColor Cyan
+
+$missing = @()
+
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    $missing += 'Python'
+} else {
+    python --version
+}
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    $missing += 'Git'
+} else {
+    git --version
+}
+
+if (-not (Get-Command code -ErrorAction SilentlyContinue)) {
+    $missing += 'VSCode'
+} else {
+    code --version
+}
+
+if ($missing.Count -eq 0) {
+    Write-Host "All prerequisites found." -ForegroundColor Green
+} else {
+    Write-Host "Missing: $($missing -join ', ')" -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
## Summary
- add CI pipelines for Lesson 00
- include requirements.txt in Lesson 00
- keep prerequisite test across lessons
- carry Lesson 01 modules/tests into Lesson 02

## Testing
- `pytest -q` in Lesson 01 source
- `pytest -q` in Lesson 02 source
- `pwsh` command for Lesson 00 (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_686a749496788329a2dba5d54bc06e23