### PR TITLE
Add Lesson 05 Flask API solution

### DIFF
--- a/Lession 05 - Flask API/source/.github/workflows/ci-cd.yml
+++ b/Lession 05 - Flask API/source/.github/workflows/ci-cd.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    paths: [ '**/source/**' ]
+  pull_request:
+    paths: [ '**/source/**' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r "Lession 05 - Flask API/source/requirements.txt"
+      - run: pytest -q "Lession 05 - Flask API/source/tests"

--- a/Lession 05 - Flask API/source/app.py
+++ b/Lession 05 - Flask API/source/app.py
@@ -1,0 +1,37 @@
+"""Simple Flask API exposing task operations."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from flask import Flask, jsonify, request
+
+from src.models import Task
+from src.utils import timed
+
+app = Flask(__name__)
+
+# in-memory storage for demo purposes
+tasks: list[Task] = []
+
+
+@app.post("/tasks")
+@timed
+def create_task():
+    """Create a new task from JSON payload."""
+    data = request.get_json(silent=True) or {}
+    title = data.get("title")
+    if not title:
+        return jsonify({"error": "title required"}), 400
+    task = Task(title)
+    tasks.append(task)
+    return jsonify(asdict(task)), 201
+
+
+@app.get("/tasks")
+def list_tasks():
+    """Return all tasks as JSON."""
+    return jsonify([asdict(t) for t in tasks])
+
+
+if __name__ == "__main__":
+    app.run()

--- a/Lession 05 - Flask API/source/azure-pipelines.yml
+++ b/Lession 05 - Flask API/source/azure-pipelines.yml
@@ -1,0 +1,15 @@
+trigger:
+- '*'
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- checkout: self
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.11'
+- script: |
+    pip install -r "Lession 05 - Flask API/source/requirements.txt"
+    pytest -q "Lession 05 - Flask API/source/tests"
+  displayName: 'Run tests'

--- a/Lession 05 - Flask API/source/main.py
+++ b/Lession 05 - Flask API/source/main.py
@@ -1,0 +1,50 @@
+"""Entry point that runs all lesson examples."""
+
+from datetime import datetime, timedelta
+
+from src.greetings import greet
+from src.math_example import remaining_tasks
+from src.schedule_example import schedule_next
+from src.time_example import elapsed_seconds, format_duration
+from src.types_example import get_value_types
+from src.venv_check import get_venv_path, is_venv_active
+from src.models import Task
+
+
+def main() -> None:
+    """Execute each example module sequentially."""
+
+    # Greeting example
+    print(greet("world"))
+
+    # Simple math example
+    print("Remaining tasks:", remaining_tasks(5, 2))
+
+    # Basic data types
+    for value, typ in get_value_types():
+        print(f"{value!r} -> {typ.__name__}")
+
+    # Time calculations
+    start = datetime.now()
+    end = start + timedelta(seconds=1)
+    print(f"Elapsed: {elapsed_seconds(start, end)}s")
+    print(f"Duration: {format_duration(start, end)}")
+
+    # Schedule next task
+    next_time = schedule_next(30, now=start)
+    print("Next task starts at", next_time.strftime("%H:%M"))
+
+    # Domain model usage
+    task = Task("close store")
+    print(f"Created task {task.id}: {task.title}")
+    task.mark_done()
+
+    # Virtual environment status
+    if is_venv_active():
+        print(f"Virtual environment: {get_venv_path()}")
+    else:
+        print("No virtual environment detected")
+
+
+if __name__ == "__main__":
+    main()

--- a/Lession 05 - Flask API/source/requirements.txt
+++ b/Lession 05 - Flask API/source/requirements.txt
@@ -1,0 +1,7 @@
+# core dependencies (if any)
+Werkzeug<3
+Flask>=2.3,<3.0
+# e.g. click==8.1.3
+
+# dev / test dependencies
+pytest>=7.0,<8.0

--- a/Lession 05 - Flask API/source/run.ps1
+++ b/Lession 05 - Flask API/source/run.ps1
@@ -1,0 +1,60 @@
+# Session 01 - Hello World/source/run.ps1
+
+# 1) Determine script & project dirs
+$scriptDir    = $PSScriptRoot
+$projectDir   = Join-Path $scriptDir '..'
+$venvDir      = Join-Path $projectDir '.venv'
+$setupScript  = Join-Path $scriptDir  'setup-venv.ps1'
+$testsDir     = Join-Path $scriptDir  'tests'
+$mainScript   = Join-Path $scriptDir  'main.py'
+
+# 2) Bootstrap the virtual-env if missing
+if (-not (Test-Path $venvDir)) {
+    Write-Host "No virtual environment found at $venvDir. Running setup-venv.ps1..." -ForegroundColor Yellow
+    & $setupScript
+    if (-not (Test-Path $venvDir)) {
+        Write-Host "ERROR: Could not create virtual environment. Aborting." -ForegroundColor Red
+        exit 1
+    }
+}
+
+# 3) Activate the venv
+$activateScript = Join-Path $venvDir 'Scripts\Activate.ps1'
+if (-not (Test-Path $activateScript)) {
+    $activateScript = Join-Path $venvDir 'bin/Activate.ps1'
+}
+if (-not (Test-Path $activateScript)) {
+    Write-Host "ERROR: Activation script not found. Aborting." -ForegroundColor Red
+    exit 1
+}
+& $activateScript
+
+# 4) Run tests (installing pytest if needed, abort on failure)
+if (Test-Path $testsDir) {
+    # ensure pytest is available
+    Write-Host "Checking for pytest..." -ForegroundColor Cyan
+    & python -m pytest --version > $null 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "pytest not found. Installing pytest..." -ForegroundColor Yellow
+        pip install pytest
+    }
+
+    # run the suite
+    Write-Host "Running tests in $testsDir..." -ForegroundColor Cyan
+    & python -m pytest $testsDir
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "❌ Tests failed with exit code $LASTEXITCODE. Aborting run." -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+    Write-Host "✅ All tests passed." -ForegroundColor Green
+} else {
+    Write-Host "No tests directory at $testsDir; skipping tests." -ForegroundColor Yellow
+}
+
+# 5) Run main.py
+if (-not (Test-Path $mainScript)) {
+    Write-Host "ERROR: main.py not found at $mainScript" -ForegroundColor Red
+    exit 1
+}
+Write-Host "Launching main.py..." -ForegroundColor Green
+python $mainScript

--- a/Lession 05 - Flask API/source/setup-venv.ps1
+++ b/Lession 05 - Flask API/source/setup-venv.ps1
@@ -1,0 +1,36 @@
+# SESSION 01 – Hello World/source/setup-venv.ps1
+
+# 1) Where am I?
+$scriptDir = $PSScriptRoot
+
+# 2) Build the paths we need
+$projectRoot  = Join-Path $scriptDir '..'
+$venvPath     = Join-Path $projectRoot '.venv'
+$reqFile      = Join-Path $scriptDir  'requirements.txt'
+
+# 3) Create the virtualenv
+Write-Host "Creating virtual environment in $venvPath"
+python -m venv $venvPath
+
+# 4) Find the activation script
+$activateScript = Join-Path $venvPath 'Scripts\Activate.ps1'
+if (-not (Test-Path $activateScript)) {
+    $activateScript = Join-Path $venvPath 'bin/Activate.ps1'
+}
+if (-not (Test-Path $activateScript)) {
+    Write-Host "ERROR: venv activation script not found. Did venv creation fail?" -ForegroundColor Red
+    exit 1
+}
+
+# 5) Activate and install
+& $activateScript
+
+if (-not (Test-Path $reqFile)) {
+    Write-Host "ERROR: Requirements file not found at $reqFile" -ForegroundColor Red
+    exit 1
+}
+Write-Host "Installing dependencies from $reqFile"
+pip install --upgrade pip
+pip install -r $reqFile
+
+Write-Host "✅ Virtual environment ready."

--- a/Lession 05 - Flask API/source/src/greetings.py
+++ b/Lession 05 - Flask API/source/src/greetings.py
@@ -1,0 +1,8 @@
+from .utils import normalize_title
+
+
+def greet(name: str | None) -> str:
+    """Return a friendly greeting."""
+    if not name:
+        raise ValueError("Name required")
+    return f"What TaskMate – Hello, {normalize_title(name)}!"

--- a/Lession 05 - Flask API/source/src/math_example.py
+++ b/Lession 05 - Flask API/source/src/math_example.py
@@ -1,0 +1,6 @@
+
+def remaining_tasks(total: int, completed: int) -> int:
+    """Return how many tasks remain."""
+    if total < 0 or completed < 0 or completed > total:
+        raise ValueError("invalid numbers")
+    return total - completed

--- a/Lession 05 - Flask API/source/src/models.py
+++ b/Lession 05 - Flask API/source/src/models.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from .utils import normalize_title, timed
+
+
+_next_id = 0
+
+def _next_task_id() -> int:
+    global _next_id
+    _next_id += 1
+    return _next_id
+
+
+@dataclass
+class Task:
+    """Simple task representation."""
+
+    title: str
+    done: bool = False
+    id: int = field(default_factory=_next_task_id, init=False)
+    created: datetime = field(default_factory=datetime.utcnow, init=False)
+
+    def __post_init__(self) -> None:
+        self.title = normalize_title(self.title)
+
+    @timed
+    def mark_done(self) -> None:
+        if not self.done:
+            self.done = True
+            print(f"Task {self.id} completed")
+        else:
+            print(f"Task {self.id} was already completed")

--- a/Lession 05 - Flask API/source/src/schedule_example.py
+++ b/Lession 05 - Flask API/source/src/schedule_example.py
@@ -1,0 +1,10 @@
+from datetime import datetime, timedelta
+
+
+def schedule_next(minutes_from_now: int, now: datetime | None = None) -> datetime:
+    """Return the timestamp minutes from ``now``."""
+    if minutes_from_now < 0:
+        raise ValueError("minutes must be positive")
+    if now is None:
+        now = datetime.now()
+    return now + timedelta(minutes=minutes_from_now)

--- a/Lession 05 - Flask API/source/src/time_example.py
+++ b/Lession 05 - Flask API/source/src/time_example.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+
+def elapsed_seconds(start: datetime, end: datetime) -> float:
+    """Return elapsed seconds between two timestamps."""
+    if start is None or end is None:
+        raise ValueError("start and end required")
+    if end < start:
+        raise ValueError("end before start")
+    return (end - start).total_seconds()
+
+
+def format_duration(start: datetime, end: datetime) -> str:
+    """Return duration formatted as 'Xm Ys'."""
+    seconds = elapsed_seconds(start, end)
+    if seconds <= 0:
+        raise ValueError("invalid duration")
+    minutes, secs = divmod(seconds, 60)
+    return f"{int(minutes)}m {int(secs)}s"

--- a/Lession 05 - Flask API/source/src/types_example.py
+++ b/Lession 05 - Flask API/source/src/types_example.py
@@ -1,0 +1,22 @@
+from typing import Iterable, Tuple, Any
+
+
+def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type]]:
+    """Return sample values and their types.
+
+    Raises ValueError if any value is ``None``.
+    """
+    if values is None:
+        values = [
+            1,
+            "Open Store",
+            True,
+            [1.0, 2.5, 3.0],
+            {1: "Open Store"},
+        ]
+    result = []
+    for val in values:
+        if val is None:
+            raise ValueError("value is missing")
+        result.append((val, type(val)))
+    return result

--- a/Lession 05 - Flask API/source/src/utils.py
+++ b/Lession 05 - Flask API/source/src/utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import functools
+import time
+
+
+def normalize_title(raw: str) -> str:
+    """Capitalize each word and strip whitespace."""
+    return raw.strip().title()
+
+
+def timed(func):
+    """Decorator printing the runtime of ``func``."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        start = time.perf_counter()
+        result = func(*args, **kwargs)
+        end = time.perf_counter()
+        print(f"{func.__name__} took {end - start:.4f}s")
+        return result
+
+    return wrapper

--- a/Lession 05 - Flask API/source/src/venv_check.py
+++ b/Lession 05 - Flask API/source/src/venv_check.py
@@ -1,0 +1,16 @@
+"""Helpers to inspect the current Python environment."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def is_venv_active() -> bool:
+    """Return True if running inside a virtual environment."""
+    return sys.prefix != sys.base_prefix
+
+
+def get_venv_path() -> Path | None:
+    """Return the path to the active virtual environment or None."""
+    return Path(sys.prefix) if is_venv_active() else None

--- a/Lession 05 - Flask API/source/tests/test_app.py
+++ b/Lession 05 - Flask API/source/tests/test_app.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import json
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from app import app, tasks
+
+
+def test_create_and_list_tasks(capsys):
+    client = app.test_client()
+    tasks.clear()
+    response = client.post('/tasks', json={'title': 'open store'})
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['title'] == 'Open Store'
+    assert data['done'] is False
+    out = capsys.readouterr().out.strip()
+    assert 'create_task took' in out
+
+    response = client.get('/tasks')
+    assert response.status_code == 200
+    assert data in response.get_json()
+
+
+def test_create_task_bad_request():
+    client = app.test_client()
+    tasks.clear()
+    resp = client.post('/tasks', json={'name': 'missing'})
+    assert resp.status_code == 400
+    resp = client.post('/tasks', data='nope', content_type='text/plain')
+    assert resp.status_code == 400
+

--- a/Lession 05 - Flask API/source/tests/test_greetings.py
+++ b/Lession 05 - Flask API/source/tests/test_greetings.py
@@ -1,0 +1,13 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+
+from src.greetings import greet
+
+def test_greet():
+    assert greet("sofia") == "What TaskMate – Hello, Sofia!"
+
+def test_greet_missing():
+    with pytest.raises(ValueError, match="Name required"):
+        greet("")

--- a/Lession 05 - Flask API/source/tests/test_main.py
+++ b/Lession 05 - Flask API/source/tests/test_main.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from datetime import datetime, timedelta
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from main import main
+
+def test_main_output(capsys):
+    # run main and capture output
+    main()
+    captured = capsys.readouterr().out.splitlines()
+    assert captured[0] == "What TaskMate – Hello, World!"
+    assert any("Remaining tasks" in line for line in captured)
+    assert any("Next task starts at" in line for line in captured)
+    assert any(line.startswith("Created task") for line in captured)
+    assert any("completed" in line for line in captured)
+    assert any(line.startswith("mark_done took") for line in captured)
+    assert any(
+        line.startswith("Virtual environment:")
+        or line == "No virtual environment detected"
+        for line in captured
+    )

--- a/Lession 05 - Flask API/source/tests/test_math_example.py
+++ b/Lession 05 - Flask API/source/tests/test_math_example.py
@@ -1,0 +1,15 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from src.math_example import remaining_tasks
+
+
+
+def test_remaining_tasks():
+    assert remaining_tasks(5, 2) == 3
+
+
+def test_remaining_tasks_invalid():
+    with pytest.raises(ValueError):
+        remaining_tasks(5, 6)

--- a/Lession 05 - Flask API/source/tests/test_models.py
+++ b/Lession 05 - Flask API/source/tests/test_models.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from src.models import Task
+
+
+def test_task_defaults_and_normalization():
+    task = Task("  open store ")
+    assert task.title == "Open Store"
+    assert isinstance(task.id, int)
+    assert isinstance(task.created, datetime)
+    assert task.done is False
+
+
+def test_mark_done_changes_state(capsys):
+    task = Task("close store")
+    task.mark_done()
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert task.done is True
+    assert captured[0] == f"Task {task.id} completed"
+    assert any(line.startswith("mark_done took") for line in captured[1:])
+    task.mark_done()
+    captured = capsys.readouterr().out.strip().splitlines()
+    assert captured[-2] == f"Task {task.id} was already completed"
+    assert captured[-1].startswith("mark_done took")

--- a/Lession 05 - Flask API/source/tests/test_schedule_example.py
+++ b/Lession 05 - Flask API/source/tests/test_schedule_example.py
@@ -1,0 +1,20 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from datetime import datetime, timedelta
+
+from src.schedule_example import schedule_next
+
+
+
+def test_schedule_next():
+    now = datetime(2023, 1, 1, 12, 0, 0)
+    result = schedule_next(30, now)
+    assert result == now + timedelta(minutes=30)
+
+
+def test_schedule_next_invalid():
+    now = datetime(2023, 1, 1, 12, 0, 0)
+    with pytest.raises(ValueError):
+        schedule_next(-5, now)

--- a/Lession 05 - Flask API/source/tests/test_time_example.py
+++ b/Lession 05 - Flask API/source/tests/test_time_example.py
@@ -1,0 +1,32 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from datetime import datetime, timedelta
+
+from src.time_example import elapsed_seconds, format_duration
+
+
+
+def test_elapsed_seconds():
+    start = datetime(2023, 1, 1, 0, 0, 0)
+    end = start + timedelta(seconds=5)
+    assert elapsed_seconds(start, end) == 5.0
+
+
+def test_elapsed_seconds_invalid():
+    start = datetime(2023, 1, 1, 0, 0, 0)
+    with pytest.raises(ValueError):
+        elapsed_seconds(start, start - timedelta(seconds=1))
+
+
+def test_format_duration():
+    start = datetime(2023, 1, 1, 0, 0, 0)
+    end = start + timedelta(seconds=65)
+    assert format_duration(start, end) == "1m 5s"
+
+
+def test_format_duration_invalid():
+    start = datetime(2023, 1, 1, 0, 0, 0)
+    with pytest.raises(ValueError):
+        format_duration(start, start)

--- a/Lession 05 - Flask API/source/tests/test_types_example.py
+++ b/Lession 05 - Flask API/source/tests/test_types_example.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+
+from src.types_example import get_value_types
+
+
+
+def test_get_value_types_defaults():
+    items = get_value_types()
+    assert (1, int) in items
+    assert ("Open Store", str) in items
+
+
+def test_get_value_types_invalid():
+    with pytest.raises(ValueError):
+        get_value_types([1, None])

--- a/Lession 05 - Flask API/source/tests/test_utils.py
+++ b/Lession 05 - Flask API/source/tests/test_utils.py
@@ -1,0 +1,19 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from src.utils import normalize_title, timed
+
+def test_normalize_title():
+    assert normalize_title("  hello world ") == "Hello World"
+
+
+def test_timed_decorator(capsys):
+    @timed
+    def sample(x):
+        return x * 2
+
+    result = sample(2)
+    output = capsys.readouterr().out.strip()
+    assert result == 4
+    assert "sample took" in output

--- a/Lession 05 - Flask API/source/tests/test_venv_check.py
+++ b/Lession 05 - Flask API/source/tests/test_venv_check.py
@@ -1,0 +1,14 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from src.venv_check import is_venv_active, get_venv_path
+
+
+def test_is_venv_active_returns_bool():
+    assert isinstance(is_venv_active(), bool)
+
+
+def test_get_venv_path_type():
+    path = get_venv_path()
+    assert path is None or path.exists()

--- a/Lession 05 - Flask API/source/tests/verify-prerequisites.ps1
+++ b/Lession 05 - Flask API/source/tests/verify-prerequisites.ps1
@@ -1,0 +1,28 @@
+Write-Host "Checking prerequisites..." -ForegroundColor Cyan
+
+$missing = @()
+
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    $missing += 'Python'
+} else {
+    python --version
+}
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    $missing += 'Git'
+} else {
+    git --version
+}
+
+if (-not (Get-Command code -ErrorAction SilentlyContinue)) {
+    $missing += 'VSCode'
+} else {
+    code --version
+}
+
+if ($missing.Count -eq 0) {
+    Write-Host "All prerequisites found." -ForegroundColor Green
+} else {
+    Write-Host "Missing: $($missing -join ', ')" -ForegroundColor Red
+    exit 1
+}


### PR DESCRIPTION
## Summary
- add implementation for Lesson 05 Flask API
- bring forward previous lesson source files
- implement simple Flask app with create/list task endpoints
- add tests for API and copy prior tests
- setup CI pipelines for GitHub and Azure DevOps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ad5dfd12c83298d46c1b042cac5bf