### PR TITLE
Add comments for basic data type examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ which files and folders to create, the code to place in each file, and the
 reason for it. Apply this approach consistently across all lessons so that
 participants can follow along without guessing any implementation details.
 
+Provide inline comments in short example code blocks (like `types_example.py`)
+to explain the purpose of each line.
+
 
 ## Tests
 

--- a/Lesson 00 - Prerequisites/01-install-vscode.md
+++ b/Lesson 00 - Prerequisites/01-install-vscode.md
@@ -14,3 +14,11 @@ If you have [winget](https://learn.microsoft.com/en-us/windows/package-manager/w
 ```powershell
 winget install -e --id Microsoft.VisualStudioCode
 ```
+
+## Why this step?
+
+Using VS Code gives us an editor with great Python support. Installing the
+extensions up front means features like IntelliSense and debugging work
+consistently throughout the course.
+## Theory example
+An integrated development environment (IDE) offers helpful features such as syntax highlighting and debugging. VS Code's extension system lets us tailor it for Python development.

--- a/Lesson 00 - Prerequisites/02-install-python.md
+++ b/Lesson 00 - Prerequisites/02-install-python.md
@@ -17,3 +17,11 @@ On Windows systems you can also install Python with:
 ```powershell
 winget install -e --id Python.Python.3.11
 ```
+
+## Why this step?
+
+Python is the language used for all subsequent lessons. Installing the
+exact 3.11 series ensures everyone has a consistent runtime and avoids
+version‑specific surprises later on.
+## Theory example
+Python is an interpreted language, meaning the interpreter executes your code line by line. Version numbers denote language features and standard library updates.

--- a/Lesson 00 - Prerequisites/03-install-git.md
+++ b/Lesson 00 - Prerequisites/03-install-git.md
@@ -15,3 +15,11 @@ Use the `setup-git.ps1` script in this folder to configure your name and email:
 ```powershell
 ./setup-git.ps1
 ```
+
+## Why this step?
+
+Git tracks changes to your code and lets you collaborate effectively. Running
+the setup script configures your identity so commits can be attributed to you
+in version history.
+## Theory example
+Git is a distributed version control system. Every clone contains the full history, enabling offline work and robust branching.

--- a/Lesson 01 - Hello World/01-build-hello-world.md
+++ b/Lesson 01 - Hello World/01-build-hello-world.md
@@ -17,3 +17,11 @@ Set up the first files and confirm Python runs correctly.
        print(f"What TaskMate – Hello, {normalize_title('world')}!")
    ```
 3. Run `python main.py` to see **What TaskMate – Hello, World!** printed.
+
+## Why this step?
+
+Starting with a tiny program verifies your editor and Python setup work.
+Placing the `normalize_title` helper in its own module demonstrates how we
+organise code for reuse throughout the course.
+## Theory example
+Python executes the code under `if __name__ == "__main__"` when you run the file directly. This pattern lets modules provide reusable functions and a standalone script.

--- a/Lesson 01 - Hello World/02-basic-data-types.md
+++ b/Lesson 01 - Hello World/02-basic-data-types.md
@@ -3,13 +3,14 @@
 Explore how Python represents common values.
 
 1. Inside the `src` folder create `types_example.py` and declare a few
-   variables:
+   variables, adding inline comments that explain what each one
+   represents:
    ```python
-   task_id = 1
-   task_title = "Open Store"
-   urgent = True
-   durations = [1.0, 2.5, 3.0]
-   lookup = {1: "Open Store"}
+   task_id = 1              # numeric identifier for the task
+   task_title = "Open Store"  # short description
+   urgent = True           # indicates if the task is urgent
+   durations = [1.0, 2.5, 3.0]  # estimated durations in hours
+   lookup = {1: "Open Store"}    # maps ids to titles
    ```
    Add a short script to print each variable and its `type()`:
    ```python
@@ -26,5 +27,18 @@ Explore how Python represents common values.
        """Return sample values and their types."""
        if values is None:
            values = [1, "Open Store", True, [1.0, 2.5, 3.0], {1: "Open Store"}]
-       return [(v, type(v)) for v in values]
-   ```
+return [(v, type(v)) for v in values]
+```
+
+## Why this step?
+
+Understanding the built‑in data types helps you predict how Python will
+handle values in later examples. Turning the prints into a function also
+keeps repeated code tidy.
+## Theory example
+- **int** stores whole numbers.
+- **str** holds text encoded in Unicode.
+- **bool** represents truth values, either `True` or `False`.
+- **list** collects items in order.
+- **dict** maps keys to values.
+These types form the building blocks for more complex structures.

--- a/Lesson 01 - Hello World/03-string-concat.md
+++ b/Lesson 01 - Hello World/03-string-concat.md
@@ -26,3 +26,11 @@ Learn different ways to join text together.
        return f"What TaskMate – Hello, {normalize_title(name)}!"
    ```
    The helper validates the input and formats the name consistently.
+
+## Why this step?
+
+String concatenation and f-strings are used frequently when producing
+messages. Encapsulating the greeting logic in a helper keeps future
+examples focused on new concepts rather than repeated boilerplate.
+## Theory example
+The `+` operator builds a new string from fragments, which can be inefficient in loops. F-strings evaluate expressions and produce a single formatted result.

--- a/Lesson 01 - Hello World/04-basic-math.md
+++ b/Lesson 01 - Hello World/04-basic-math.md
@@ -20,3 +20,11 @@ Introduce a quick calculation using integers.
        return total - completed
    ```
    Later steps import this helper instead of repeating the math.
+
+## Why this step?
+
+Basic arithmetic often forms the core of more complex logic. Wrapping the
+calculation in a function lets us validate the inputs and reuse the code
+when we start building the task tracker.
+## Theory example
+Integers can be combined using operators like `+`, `-`, `*`, and `/`. Python automatically promotes to long integers so calculations won't overflow.

--- a/Lesson 01 - Hello World/05-time-calculations.md
+++ b/Lesson 01 - Hello World/05-time-calculations.md
@@ -26,3 +26,11 @@ Measure how long an operation takes.
        return (end - start).total_seconds()
    ```
    Other modules import this function when they need to measure durations.
+
+## Why this step?
+
+Many applications track how long operations take. Validating the start and
+end times prevents confusing negative durations, and using a helper keeps
+the timing logic in one place.
+## Theory example
+`datetime` objects represent a precise point in time. Subtracting two datetimes yields a `timedelta` that expresses the duration between them.

--- a/Lesson 01 - Hello World/06-task-duration.md
+++ b/Lesson 01 - Hello World/06-task-duration.md
@@ -26,4 +26,12 @@ Format a time delta into minutes and seconds.
        minutes, secs = divmod(seconds, 60)
        return f"{int(minutes)}m {int(secs)}s"
    ```
-   It calls `elapsed_seconds` from the previous step and validates the result.
+It calls `elapsed_seconds` from the previous step and validates the result.
+
+## Why this step?
+
+Formatting durations into minutes and seconds makes the output easy to read.
+Using the shared helper centralises error handling so later modules stay
+focused on their own logic.
+## Theory example
+`divmod` returns both the quotient and remainder of a division. It's handy for converting total seconds into minutes and seconds without extra calculations.

--- a/Lesson 01 - Hello World/07-schedule-start.md
+++ b/Lesson 01 - Hello World/07-schedule-start.md
@@ -22,4 +22,12 @@ Determine a future start time.
            now = datetime.now()
        return now + timedelta(minutes=minutes_from_now)
    ```
-   Other steps import it whenever they need to plan ahead.
+  Other steps import it whenever they need to plan ahead.
+
+## Why this step?
+
+Scheduling is a core feature of a task manager. By isolating the logic for
+calculating future start times we make it easier to test and reuse across
+the application.
+## Theory example
+`timedelta` represents a duration rather than a moment in time. Adding it to a `datetime` produces a new timestamp in the future.

--- a/Lesson 01 - Hello World/source/src/types_example.py
+++ b/Lesson 01 - Hello World/source/src/types_example.py
@@ -1,5 +1,20 @@
 from typing import Iterable, Tuple, Any
 
+# numeric identifier for the task
+task_id = 1
+
+# short title describing the task
+task_title = "Open Store"
+
+# marks whether the task is urgent
+urgent = True
+
+# possible task durations in hours
+durations = [1.0, 2.5, 3.0]
+
+# lookup table mapping ids to titles
+lookup = {1: "Open Store"}
+
 
 def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type]]:
     """Return sample values and their types.
@@ -7,13 +22,7 @@ def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type
     Raises ValueError if any value is ``None``.
     """
     if values is None:
-        values = [
-            1,
-            "Open Store",
-            True,
-            [1.0, 2.5, 3.0],
-            {1: "Open Store"},
-        ]
+        values = [task_id, task_title, urgent, durations, lookup]
     result = []
     for val in values:
         if val is None:

--- a/Lesson 02 - Virtual Environment/01-create-venv.md
+++ b/Lesson 02 - Virtual Environment/01-create-venv.md
@@ -6,3 +6,11 @@
    - Windows: `.venv\Scripts\activate`
    - macOS/Linux: `source .venv/bin/activate`
 4. Upgrade pip with `python -m pip install --upgrade pip`.
+
+## Why this step?
+
+A virtual environment keeps project dependencies isolated from other Python
+installs on your system. Upgrading pip ensures package installations work
+reliably in later lessons.
+## Theory example
+The `venv` module copies the Python interpreter to a new directory. Any packages installed while it's active stay within that directory.

--- a/Lesson 02 - Virtual Environment/02-freeze-dependencies.md
+++ b/Lesson 02 - Virtual Environment/02-freeze-dependencies.md
@@ -2,3 +2,11 @@
 
 1. Ensure the virtual environment is active.
 2. Run `pip freeze > requirements.txt` to capture installed packages.
+
+## Why this step?
+
+The requirements file lists exact package versions so teammates and the CI
+pipeline install the same dependencies, avoiding "works on my machine"
+problems.
+## Theory example
+`pip freeze` outputs every package and its pinned version number. Checking this file into source control documents your environment.

--- a/Lesson 02 - Virtual Environment/source/src/types_example.py
+++ b/Lesson 02 - Virtual Environment/source/src/types_example.py
@@ -1,5 +1,20 @@
 from typing import Iterable, Tuple, Any
 
+# numeric identifier for the task
+task_id = 1
+
+# short title describing the task
+task_title = "Open Store"
+
+# marks whether the task is urgent
+urgent = True
+
+# possible task durations in hours
+durations = [1.0, 2.5, 3.0]
+
+# lookup table mapping ids to titles
+lookup = {1: "Open Store"}
+
 
 def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type]]:
     """Return sample values and their types.
@@ -7,13 +22,7 @@ def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type
     Raises ValueError if any value is ``None``.
     """
     if values is None:
-        values = [
-            1,
-            "Open Store",
-            True,
-            [1.0, 2.5, 3.0],
-            {1: "Open Store"},
-        ]
+        values = [task_id, task_title, urgent, durations, lookup]
     result = []
     for val in values:
         if val is None:

--- a/Lesson 03 - Domain Model/01-create-task-class.md
+++ b/Lesson 03 - Domain Model/01-create-task-class.md
@@ -24,3 +24,11 @@
    ```
 3. The dataclass automatically stores the creation time and assigns a unique
    `id` whenever a `Task` is instantiated. Later lessons extend this class.
+
+## Why this step?
+
+Encapsulating task details in a dataclass keeps related data together and
+reduces boilerplate code. Generating a unique identifier now prepares us for
+tracking tasks in memory and eventually in a database.
+## Theory example
+`@dataclass` automatically generates `__init__`, `__repr__`, and other methods based on your attribute definitions. It simplifies classes that primarily store data.

--- a/Lesson 03 - Domain Model/02-normalize-title.md
+++ b/Lesson 03 - Domain Model/02-normalize-title.md
@@ -11,3 +11,11 @@
        self.title = normalize_title(self.title)
    ```
 4. Normalising here means every `Task` instance stores a consistent title.
+
+## Why this step?
+
+Cleaning the title as soon as the object is created prevents messy data from
+creeping into later operations. Placing this logic in `__post_init__` keeps
+the class easy to use without extra calls.
+## Theory example
+`__post_init__` runs immediately after the dataclass-generated `__init__`. It's the ideal place for validation or normalisation logic.

--- a/Lesson 03 - Domain Model/03-add-mark-done.md
+++ b/Lesson 03 - Domain Model/03-add-mark-done.md
@@ -11,3 +11,11 @@
    ```
 2. The method toggles the `done` flag and logs the result, making status
    changes explicit when the code runs.
+
+## Why this step?
+
+Providing a clear `mark_done` method encapsulates state changes in one
+place. Logging the result helps during debugging and demonstrates how
+methods can report their own actions.
+## Theory example
+Methods attached to a class operate on the instance (`self`). They let each object manage its own behaviour in addition to storing data.

--- a/Lesson 03 - Domain Model/source/src/types_example.py
+++ b/Lesson 03 - Domain Model/source/src/types_example.py
@@ -1,5 +1,20 @@
 from typing import Iterable, Tuple, Any
 
+# numeric identifier for the task
+task_id = 1
+
+# short title describing the task
+task_title = "Open Store"
+
+# marks whether the task is urgent
+urgent = True
+
+# possible task durations in hours
+durations = [1.0, 2.5, 3.0]
+
+# lookup table mapping ids to titles
+lookup = {1: "Open Store"}
+
 
 def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type]]:
     """Return sample values and their types.
@@ -7,13 +22,7 @@ def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type
     Raises ValueError if any value is ``None``.
     """
     if values is None:
-        values = [
-            1,
-            "Open Store",
-            True,
-            [1.0, 2.5, 3.0],
-            {1: "Open Store"},
-        ]
+        values = [task_id, task_title, urgent, durations, lookup]
     result = []
     for val in values:
         if val is None:

--- a/Lesson 04 - Diagnostics Decorator/01-implement-timed-decorator.md
+++ b/Lesson 04 - Diagnostics Decorator/01-implement-timed-decorator.md
@@ -18,3 +18,11 @@
    ```
 3. This helper adds lightweight diagnostics without changing the wrapped
    function's logic.
+
+## Why this step?
+
+Decorators let us add features like timing without cluttering the core
+business code. Measuring execution time now helps identify slow spots as the
+project grows.
+## Theory example
+A decorator is a function that returns another function. Using `@wraps` preserves the original function's metadata such as its name and docstring.

--- a/Lesson 04 - Diagnostics Decorator/02-apply-decorator.md
+++ b/Lesson 04 - Diagnostics Decorator/02-apply-decorator.md
@@ -11,3 +11,11 @@
        ...
    ```
 3. Run `python main.py` and complete a task to see how long the call took.
+
+## Why this step?
+
+Applying the decorator shows how easily cross-cutting concerns like timing
+can be added. It also demonstrates that decorators do not alter the method
+signature, keeping the rest of the code unchanged.
+## Theory example
+Decorators can stack. If multiple decorators wrap a function, they execute in reverse order of appearance, each layering behaviour on top of the other.

--- a/Lesson 04 - Diagnostics Decorator/source/src/types_example.py
+++ b/Lesson 04 - Diagnostics Decorator/source/src/types_example.py
@@ -1,5 +1,20 @@
 from typing import Iterable, Tuple, Any
 
+# numeric identifier for the task
+task_id = 1
+
+# short title describing the task
+task_title = "Open Store"
+
+# marks whether the task is urgent
+urgent = True
+
+# possible task durations in hours
+durations = [1.0, 2.5, 3.0]
+
+# lookup table mapping ids to titles
+lookup = {1: "Open Store"}
+
 
 def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type]]:
     """Return sample values and their types.
@@ -7,13 +22,7 @@ def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type
     Raises ValueError if any value is ``None``.
     """
     if values is None:
-        values = [
-            1,
-            "Open Store",
-            True,
-            [1.0, 2.5, 3.0],
-            {1: "Open Store"},
-        ]
+        values = [task_id, task_title, urgent, durations, lookup]
     result = []
     for val in values:
         if val is None:

--- a/Lesson 05 - Flask API/01-install-flask.md
+++ b/Lesson 05 - Flask API/01-install-flask.md
@@ -8,3 +8,11 @@
 3. Append `Flask==2.3` to `requirements.txt` so everyone installs the same
    version.
 4. Keeping the requirements file updated ensures consistent environments.
+
+## Why this step?
+
+Flask provides the lightweight web framework we use to expose the task
+manager via HTTP. Pinning the version avoids unexpected behaviour if a newer
+release introduces breaking changes.
+## Theory example
+A web framework handles HTTP requests and responses for you. Flask is minimal, letting you build routes with simple decorators while adding only what you need.

--- a/Lesson 05 - Flask API/02-create-flask-api.md
+++ b/Lesson 05 - Flask API/02-create-flask-api.md
@@ -23,3 +23,11 @@
        return jsonify([task.__dict__ for task in tasks])
    ```
 3. The API reuses the `Task` dataclass and logs how long task creation takes.
+
+## Why this step?
+
+By exposing our domain model through HTTP we enable other applications to
+interact with it. The timed decorator lets us monitor performance without
+cluttering the endpoint code.
+## Theory example
+Flask uses decorators such as `@app.post` to register functions as handlers for HTTP endpoints. Each route function returns a response object or data that Flask converts to JSON.

--- a/Lesson 05 - Flask API/03-run-server.md
+++ b/Lesson 05 - Flask API/03-run-server.md
@@ -7,3 +7,11 @@
 2. Open <http://127.0.0.1:5000/tasks> in a browser or use `curl` to send
    requests.
 3. Interacting with the endpoints confirms the API is working locally.
+
+## Why this step?
+
+Running the server yourself lets you experiment with requests and see
+immediate feedback. Catching issues now is easier than after deploying to a
+cloud environment.
+## Theory example
+The development server reloads on changes. It's designed for local testing and not for production use, but it makes iteration fast during development.

--- a/Lesson 05 - Flask API/source/src/types_example.py
+++ b/Lesson 05 - Flask API/source/src/types_example.py
@@ -1,5 +1,20 @@
 from typing import Iterable, Tuple, Any
 
+# numeric identifier for the task
+task_id = 1
+
+# short title describing the task
+task_title = "Open Store"
+
+# marks whether the task is urgent
+urgent = True
+
+# possible task durations in hours
+durations = [1.0, 2.5, 3.0]
+
+# lookup table mapping ids to titles
+lookup = {1: "Open Store"}
+
 
 def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type]]:
     """Return sample values and their types.
@@ -7,13 +22,7 @@ def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type
     Raises ValueError if any value is ``None``.
     """
     if values is None:
-        values = [
-            1,
-            "Open Store",
-            True,
-            [1.0, 2.5, 3.0],
-            {1: "Open Store"},
-        ]
+        values = [task_id, task_title, urgent, durations, lookup]
     result = []
     for val in values:
         if val is None:

--- a/Lesson 06 - Azure Functions/01-install-packages.md
+++ b/Lesson 06 - Azure Functions/01-install-packages.md
@@ -9,3 +9,11 @@
    serverless environment has the same packages.
 4. These libraries allow the Flask app to run inside Azure Functions and expose
    Swagger UI.
+
+## Why this step?
+
+Azure Functions provides the serverless platform for our application.
+Installing the required packages locally lets us develop and test the function
+before deploying it to the cloud.
+## Theory example
+Serverless platforms execute small pieces of code in response to events. Dependencies like `azure-functions` provide the glue between your code and the hosting environment.

--- a/Lesson 06 - Azure Functions/02-wrap-as-azure-function.md
+++ b/Lesson 06 - Azure Functions/02-wrap-as-azure-function.md
@@ -12,3 +12,10 @@
    ```
 3. `WsgiMiddleware` allows Azure Functions to invoke the Flask app, while
    `Swagger` provides interactive docs at `/api/apidocs`.
+
+## Why this step?
+
+This wrapper bridges the gap between Flask and the Azure Functions runtime.
+Adding Swagger gives you a ready-made UI to explore the API once deployed.
+## Theory example
+`WsgiMiddleware` adapts a WSGI-compatible app so the Functions runtime can call it. Swagger reads comments and annotations to generate API documentation.

--- a/Lesson 06 - Azure Functions/03-run-locally.md
+++ b/Lesson 06 - Azure Functions/03-run-locally.md
@@ -7,3 +7,10 @@
 2. When the host prints a URL, open it and append `/api/apidocs` to access the
    Swagger UI.
 3. Running locally ensures the function wrapper works before deploying.
+
+## Why this step?
+
+Testing locally helps catch configuration issues early. It also lets you
+experiment with the Swagger interface before exposing the API publicly.
+## Theory example
+The local Functions host emulates the cloud runtime. It watches your files and reloads when changes are detected.

--- a/Lesson 06 - Azure Functions/source/src/types_example.py
+++ b/Lesson 06 - Azure Functions/source/src/types_example.py
@@ -1,5 +1,20 @@
 from typing import Iterable, Tuple, Any
 
+# numeric identifier for the task
+task_id = 1
+
+# short title describing the task
+task_title = "Open Store"
+
+# marks whether the task is urgent
+urgent = True
+
+# possible task durations in hours
+durations = [1.0, 2.5, 3.0]
+
+# lookup table mapping ids to titles
+lookup = {1: "Open Store"}
+
 
 def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type]]:
     """Return sample values and their types.
@@ -7,13 +22,7 @@ def get_value_types(values: Iterable[Any] | None = None) -> list[Tuple[Any, type
     Raises ValueError if any value is ``None``.
     """
     if values is None:
-        values = [
-            1,
-            "Open Store",
-            True,
-            [1.0, 2.5, 3.0],
-            {1: "Open Store"},
-        ]
+        values = [task_id, task_title, urgent, durations, lookup]
     result = []
     for val in values:
         if val is None:

--- a/Lesson 07 - Unit Tests/01-install-testing-tools.md
+++ b/Lesson 07 - Unit Tests/01-install-testing-tools.md
@@ -7,3 +7,11 @@
    ```
 3. Add `pytest` and `pytest-mock` to `requirements.txt` so the pipeline installs
    them during CI.
+
+## Why this step?
+
+Testing tools help us verify behaviour automatically. Keeping them in the
+requirements file means our CI system and every developer run the same test
+suite.
+## Theory example
+`pytest` finds tests by filename and function name patterns. Plugins like `pytest-mock` extend its capabilities for specific scenarios.

--- a/Lesson 07 - Unit Tests/02-write-tests.md
+++ b/Lesson 07 - Unit Tests/02-write-tests.md
@@ -12,3 +12,11 @@
    Flask and Azure Function entry points using fixtures from `pytest-mock`.
 3. Organising tests this way keeps the suite easy to maintain and lets CI catch
    regressions automatically.
+
+## Why this step?
+
+Writing tests forces us to think about expected behaviour and guards against
+future changes breaking existing features. Using pytest-mock simplifies
+testing code that relies on external services.
+## Theory example
+A unit test focuses on a single function or method in isolation. Mock objects replace real dependencies so you can assert behaviour without calling external systems.

--- a/Lesson 07 - Unit Tests/03-run-tests.md
+++ b/Lesson 07 - Unit Tests/03-run-tests.md
@@ -5,3 +5,10 @@
    pytest -q
    ```
 2. A green test run shows the application behaves as expected.
+
+## Why this step?
+
+Running the tests regularly gives quick feedback on your progress. It also
+mirrors what happens in CI, so fixing issues locally saves time later.
+## Theory example
+The `-q` flag makes pytest output less verbose, showing only test names and final results. Use it for quick checks during development.

--- a/Lesson 08 - Security/01-install-pyjwt.md
+++ b/Lesson 08 - Security/01-install-pyjwt.md
@@ -7,3 +7,11 @@
    ```
 3. Add `pyjwt[crypto]` to `requirements.txt` so the application can validate
    tokens in every environment.
+
+## Why this step?
+
+JWTs provide a standard way to authenticate requests. Installing the library
+now lets us secure the API in upcoming steps and keeps required packages
+synchronised across machines.
+## Theory example
+A JSON Web Token encodes user claims as a signed payload. Clients include the token in the Authorization header to prove their identity.

--- a/Lesson 08 - Security/02-add-jwt-decorator.md
+++ b/Lesson 08 - Security/02-add-jwt-decorator.md
@@ -22,3 +22,11 @@
    ```
 3. The decorator rejects requests without a valid JWT so only authorised
    clients can call the API.
+
+## Why this step?
+
+Placing authentication logic in a decorator keeps the endpoints clean while
+still enforcing security. Using JWT lets the server verify callers without
+storing session state.
+## Theory example
+JWTs carry a signature generated with a secret key. When you decode the token with the same key, you can trust the claims haven't been tampered with.

--- a/Lesson 08 - Security/03-configure-easyauth.md
+++ b/Lesson 08 - Security/03-configure-easyauth.md
@@ -6,3 +6,10 @@
    to validate JWTs with the same signing key.
 3. This combination secures the API both during development and after
    deployment.
+
+## Why this step?
+
+Requiring JWTs locally mirrors the security settings used in Azure. Testing
+authentication early helps avoid surprises when you deploy the function.
+## Theory example
+EasyAuth intercepts HTTP requests before they reach your app, verifying the token and attaching user information to the request headers.

--- a/Lesson 09 - CI CD/01-create-workflow-file.md
+++ b/Lesson 09 - CI CD/01-create-workflow-file.md
@@ -24,3 +24,11 @@
    ```
 3. Configure the secrets `AZURE_FUNCTIONAPP_NAME` and `AZURE_CREDENTIALS` in the
    repository so the action can deploy your function app.
+
+## Why this step?
+
+Automated workflows ensure tests run and the app deploys the same way every
+time code is pushed. Storing credentials as secrets keeps them out of the
+repository while still enabling deployment.
+## Theory example
+Continuous Integration servers clone the repository into a fresh environment for each run. This guarantees that builds do not rely on artefacts from previous runs.

--- a/Lesson 09 - CI CD/02-create-azure-pipeline.md
+++ b/Lesson 09 - CI CD/02-create-azure-pipeline.md
@@ -24,3 +24,11 @@
    ```
 2. Define variables `AZURE_FUNCTIONAPP_NAME` and `AZURE_CREDENTIALS` in the
    pipeline settings so the deployment step can authenticate.
+
+## Why this step?
+
+Azure DevOps offers a similar pipeline experience to GitHub Actions. Having
+both examples shows how CI/CD concepts transfer across tools and lets you
+choose the platform that fits your team.
+## Theory example
+Pipeline YAML defines a series of tasks executed on a hosted agent. Variables allow you to swap out values like resource names without editing the YAML.

--- a/Lesson 09 - CI CD/03-trigger-pipeline.md
+++ b/Lesson 09 - CI CD/03-trigger-pipeline.md
@@ -9,3 +9,11 @@
 2. Monitor the GitHub Actions page or Azure DevOps pipeline to ensure the build
    runs and deploys the function app. Any failing tests will stop the
    deployment.
+
+## Why this step?
+
+Seeing the pipeline execute reinforces how code changes lead to automated
+testing and deployment. Watching for failures helps you respond quickly when
+issues arise.
+## Theory example
+CI/CD encourages small, frequent changes. Each push triggers a new pipeline run, providing rapid feedback on whether the code is ready to deploy.


### PR DESCRIPTION
## Summary
- document each variable purpose in lesson on basic data types
- include commented variables in reference `types_example.py`
- clarify in AGENTS.md that short code samples should contain inline comments
- expand instructions with theory examples for each step

## Testing
- `pytest -q` *(fails: 47 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ae97d719083299ac0cfd9ae5df115